### PR TITLE
Add response detail view

### DIFF
--- a/ssn/apps/operaciones/templates/lists/lista_solicitudes.html
+++ b/ssn/apps/operaciones/templates/lists/lista_solicitudes.html
@@ -60,14 +60,15 @@
                 <div class="flex items-center justify-center md:justify-start">
                   {% with respuesta=solicitud.respuestas.first %}
                     {% if respuesta %}
+                      {% url 'operaciones:detalle_respuesta' pk=respuesta.id as resp_url %}
                       {% if respuesta.es_error %}
-                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                        <a href="{{ resp_url }}" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800 hover:underline">
                           <i class="fas fa-times-circle mr-1"></i>Error ({{ respuesta.status_http }})
-                        </span>
+                        </a>
                       {% else %}
-                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                        <a href="{{ resp_url }}" class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800 hover:underline">
                           <i class="fas fa-check-circle mr-1"></i>OK ({{ respuesta.status_http }})
-                        </span>
+                        </a>
                       {% endif %}
                     {% else %}
                       <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">

--- a/ssn/apps/operaciones/templates/lists/respuesta_detalle.html
+++ b/ssn/apps/operaciones/templates/lists/respuesta_detalle.html
@@ -1,0 +1,25 @@
+{% extends "lists/partials/_base.html" %}
+{% block title %}Detalle de Respuesta{% endblock %}
+
+{% block card_content %}
+  <div class="bg-white/70 border border-gray-200 rounded-lg shadow-sm p-6 overflow-hidden">
+    <h3 class="text-lg font-bold text-blue-600 truncate mb-6">
+      Solicitud ID:
+      <span id="uuidSolicitud" class="font-medium text-blue-800 italic cursor-pointer hover:text-blue-600 hover:underline transition duration-200">
+        {{ response_obj.solicitud.uuid }}
+      </span>
+    </h3>
+    <h4 class="text-md font-semibold mb-2">Payload Enviado</h4>
+    <pre id="payloadContent" class="bg-gray-50 p-3 border rounded mb-4 max-h-64 overflow-auto">{{ formatted_payload }}</pre>
+    <h4 class="text-md font-semibold mb-2">Respuesta Recibida</h4>
+    <pre id="responseContent" class="bg-gray-50 p-3 border rounded max-h-64 overflow-auto">{{ formatted_response }}</pre>
+  </div>
+{% endblock %}
+
+{% block extra_js %}
+<script>
+  document.addEventListener('DOMContentLoaded', function() {
+    initCopyToClipboard('#uuidSolicitud', '#uuidSolicitud', 'UUID copiado al portapapeles', 'Error al copiar el UUID');
+  });
+</script>
+{% endblock %}

--- a/ssn/apps/operaciones/urls.py
+++ b/ssn/apps/operaciones/urls.py
@@ -9,6 +9,7 @@ from .views import (
     OperacionEditView,
     OperacionViewDetailView,
     OperationTableView,
+    SolicitudResponseDetailView,
     PrevisualizarOperacionesView,
     TipoOperacionFormView,
 )
@@ -64,4 +65,10 @@ urlpatterns = [
     ),
     # Listado de todas las solicitudes base
     path("solicitudes/", BaseRequestListView.as_view(), name="lista_solicitudes"),
+    # Detalle de una respuesta generada
+    path(
+        "solicitudes/respuesta/<int:pk>/",
+        SolicitudResponseDetailView.as_view(),
+        name="detalle_respuesta",
+    ),
 ]


### PR DESCRIPTION
## Summary
- add `SolicitudResponseDetailView` to show saved SSN responses
- make status badge in list clickable
- link new url pattern to view
- add template for detail

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: POSTGRES_DB env var missing)*

------
https://chatgpt.com/codex/tasks/task_e_68473b2f4ad88320a9fdc6069677ee70